### PR TITLE
Fix a typo

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { SupportedChainId, Registrar } from '@deusfinance/synchronizer-sdk'
-import { hooks, Muon } from './synchronizer'
+import { hooks, Muon } from './Synchronizer'
 
 /*
  * Internal data is updated once every 60 secondes. If you want access to the

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 
-import { store, SynchronizerUpdater } from './synchronizer'
+import { store, SynchronizerUpdater } from './Synchronizer'
 import App from './App'
 
 ReactDOM.render(


### PR DESCRIPTION
The word "synchronizer" was declared with the capital letters in the files.